### PR TITLE
Changed author to object with name.

### DIFF
--- a/templates/macro.html
+++ b/templates/macro.html
@@ -247,13 +247,13 @@
     <!--<span class="glyphicon glyphicon-user"></span>-->
     {% if article.author %}
       <b> · </b>
-      {% if AUTHORS[article.author] %}
-        {% set author_url = AUTHORS[article.author] %}
+      {% if article.author.name in AUTHORS %}
+        {% set author_url = AUTHORS[article.author.name] %}
       {% else %}
-        {% set author_url = ["/author/",article.author,".html"]|join %}
+        {% set author_url = ["/author/",article.author.name,".html"]|join %}
       {% endif %}
     {% endif %}
-    <a href="{{ genurl( author_url ) }}">{{ article.author }}</a>
+    <a href="{{ genurl( author_url ) }}">{{ article.author.name }}</a>
   </span>
 {% endmacro %}
 


### PR DESCRIPTION
It looks like the article's author is not just a string anymore, but an object. So looking up `article.author` in `AUTHORS` dict never works, and the custom author URL is not picked up. This PR fixes the problem.